### PR TITLE
Add Block interface

### DIFF
--- a/ast.go
+++ b/ast.go
@@ -7,16 +7,17 @@ type Node interface {
 	node()
 }
 
-func (_ *StyleSheet) node()     {}
-func (_ Rules) node()           {}
-func (_ *AtRule) node()         {}
-func (_ *QualifiedRule) node()  {}
-func (_ Declarations) node()    {}
-func (_ *Declaration) node()    {}
-func (_ ComponentValues) node() {}
-func (_ *SimpleBlock) node()    {}
-func (_ *Function) node()       {}
-func (_ *Token) node()          {}
+func (_ *StyleSheet) node()       {}
+func (_ Rules) node()             {}
+func (_ *AtRule) node()           {}
+func (_ *QualifiedRule) node()    {}
+func (_ Declarations) node()      {}
+func (_ *Declaration) node()      {}
+func (_ ComponentValues) node()   {}
+func (_ *SimpleBlock) node()      {}
+func (_ *DeclarationBlock) node() {}
+func (_ *Function) node()         {}
+func (_ *Token) node()            {}
 
 // StyleSheet represents a top-level CSS3 stylesheet.
 type StyleSheet struct {
@@ -39,14 +40,14 @@ func (_ *QualifiedRule) rule() {}
 type AtRule struct {
 	Name    string
 	Prelude ComponentValues
-	Block   *SimpleBlock
+	Block   Block
 	Pos     Pos
 }
 
 // QualifiedRule represents an unnamed rule that includes a prelude and block.
 type QualifiedRule struct {
 	Prelude ComponentValues
-	Block   *SimpleBlock
+	Block   Block
 	Pos     Pos
 }
 
@@ -86,11 +87,27 @@ func (_ *SimpleBlock) componentValue() {}
 func (_ *Function) componentValue()    {}
 func (_ *Token) componentValue()       {}
 
+// Block represents a Block in Rule
+type Block interface {
+	Node
+	block()
+}
+
+func (_ *SimpleBlock) block()      {}
+func (_ *DeclarationBlock) block() {}
+
 // SimpleBlock represents a {-block, [-block, or (-block.
 type SimpleBlock struct {
 	Token  *Token
 	Values ComponentValues
 	Pos    Pos
+}
+
+// DeclarationBlock represents parsed SimpleBlock with ParseDeclaration
+type DeclarationBlock struct {
+	Token        *Token
+	Declarations Declarations
+	Pos          Pos
 }
 
 // Function represents a function call with a list of arguments.
@@ -196,6 +213,8 @@ func Position(n Node) Pos {
 			return Position(n[0])
 		}
 	case *SimpleBlock:
+		return n.Pos
+	case *DeclarationBlock:
 		return n.Pos
 	case *Function:
 		return n.Pos

--- a/ast_test.go
+++ b/ast_test.go
@@ -9,7 +9,7 @@ import (
 func TestNode(t *testing.T) {
 	var a []Node
 	a = append(a, &StyleSheet{}, &AtRule{}, &QualifiedRule{}, &Declaration{})
-	a = append(a, &SimpleBlock{}, &Function{}, &Token{})
+	a = append(a, &SimpleBlock{}, &DeclarationBlock{}, &Function{}, &Token{})
 	a = append(a, Rules{}, Declarations{}, ComponentValues{})
 	for _, n := range a {
 		n.node()
@@ -51,6 +51,7 @@ func TestPosition(t *testing.T) {
 		{in: ComponentValues{&Token{Pos: Pos{1, 2}}}, pos: Pos{1, 2}},
 		{in: ComponentValues{}, pos: Pos{}},
 		{in: &SimpleBlock{Pos: Pos{1, 2}}, pos: Pos{1, 2}},
+		{in: &DeclarationBlock{Pos: Pos{1, 2}}, pos: Pos{1, 2}},
 		{in: &Function{Pos: Pos{1, 2}}, pos: Pos{1, 2}},
 		{in: &Token{Pos: Pos{1, 2}}, pos: Pos{1, 2}},
 	}

--- a/printer.go
+++ b/printer.go
@@ -112,6 +112,30 @@ func (p *Printer) Print(w io.Writer, n Node) (err error) {
 			_, _ = w.Write([]byte{')'})
 		}
 
+	case *DeclarationBlock:
+		if n == nil {
+			return nil
+		}
+		switch n.Token.Tok {
+		case LBraceToken:
+			_, _ = w.Write([]byte{'{'})
+		case LBrackToken:
+			_, _ = w.Write([]byte{'['})
+		case LParenToken:
+			_, _ = w.Write([]byte{'('})
+		}
+
+		_ = p.Print(w, n.Declarations)
+
+		switch n.Token.Tok {
+		case LBraceToken:
+			_, _ = w.Write([]byte{'}'})
+		case LBrackToken:
+			_, _ = w.Write([]byte{']'})
+		case LParenToken:
+			_, _ = w.Write([]byte{')'})
+		}
+
 	case *Function:
 		if n == nil {
 			return nil

--- a/printer_test.go
+++ b/printer_test.go
@@ -38,59 +38,80 @@ func TestPrinter_Print(t *testing.T) {
 						&css.Token{Tok: css.IdentToken, Value: "my-rule"},
 					},
 				},
+				&css.AtRule{
+					Name: "qux",
+					Prelude: []css.ComponentValue{
+						&css.Token{Tok: css.WhitespaceToken, Value: " "},
+						&css.Token{Tok: css.IdentToken, Value: "your-rule"},
+					},
+					Block: &css.DeclarationBlock{
+						Token: &css.Token{Tok: css.LBraceToken},
+						Declarations: css.Declarations{
+							&css.Declaration{
+								Name: "font-size",
+								Values: []css.ComponentValue{
+									&css.Token{Tok: css.WhitespaceToken},
+									&css.Token{Tok: css.DimensionToken, Value: "10px"},
+								},
+								Important: true,
+							},
+						},
+					},
+				},
 			},
-		}, s: `foo bar{font-size:10px} @baz my-rule;`},
+		}, s: `foo bar{font-size:10px} @baz my-rule; @qux your-rule{font-size:10px!important;}`},
 
 		// Test that nil values are safe to print.
-		{in: (*css.StyleSheet)(nil), s: ``},     // 1
-		{in: (css.Rules)(nil), s: ``},           // 2
-		{in: (*css.AtRule)(nil), s: ``},         // 3
-		{in: (*css.QualifiedRule)(nil), s: ``},  // 4
-		{in: (css.Declarations)(nil), s: ``},    // 5
-		{in: (*css.Declaration)(nil), s: ``},    // 6
-		{in: (css.ComponentValues)(nil), s: ``}, // 7
-		{in: (*css.SimpleBlock)(nil), s: ``},    // 8
-		{in: (*css.Function)(nil), s: ``},       // 9
-		{in: (*css.Token)(nil), s: ``},          // 10
+		{in: (*css.StyleSheet)(nil), s: ``},       // 1
+		{in: (css.Rules)(nil), s: ``},             // 2
+		{in: (*css.AtRule)(nil), s: ``},           // 3
+		{in: (*css.QualifiedRule)(nil), s: ``},    // 4
+		{in: (css.Declarations)(nil), s: ``},      // 5
+		{in: (*css.Declaration)(nil), s: ``},      // 6
+		{in: (css.ComponentValues)(nil), s: ``},   // 7
+		{in: (*css.SimpleBlock)(nil), s: ``},      // 8
+		{in: (*css.DeclarationBlock)(nil), s: ``}, // 9
+		{in: (*css.Function)(nil), s: ``},         // 10
+		{in: (*css.Token)(nil), s: ``},            // 11
 
 		// Test individual tokens.
-		{in: &css.Token{Tok: css.IdentToken, Value: "foo"}, s: `foo`},                  // 11
-		{in: &css.Token{Tok: css.FunctionToken, Value: "foo"}, s: `foo(`},              // 11
-		{in: &css.Token{Tok: css.AtKeywordToken, Value: "☃"}, s: `@☃`},                 // 11
-		{in: &css.Token{Tok: css.HashToken, Value: "foo"}, s: `#foo`},                  // 11
-		{in: &css.Token{Tok: css.StringToken, Value: "foo", Ending: '"'}, s: `"foo"`},  // 11
-		{in: &css.Token{Tok: css.StringToken, Value: "foo", Ending: '\''}, s: `'foo'`}, // 11
-		{in: &css.Token{Tok: css.BadStringToken}, s: `''`},                             // 11
-		{in: &css.Token{Tok: css.URLToken, Value: "foo"}, s: `url(foo)`},               // 11
-		{in: &css.Token{Tok: css.BadURLToken, Value: "foo"}, s: `url()`},               // 11
-		{in: &css.Token{Tok: css.DelimToken, Value: "."}, s: `.`},                      // 11
-		{in: &css.Token{Tok: css.NumberToken, Value: "-20.3E2"}, s: `-20.3E2`},         // 11
-		{in: &css.Token{Tok: css.PercentageToken, Value: "100%"}, s: `100%`},           // 11
-		{in: &css.Token{Tok: css.DimensionToken, Value: "10cm"}, s: `10cm`},            // 11
-		{in: &css.Token{Tok: css.WhitespaceToken, Value: "  "}, s: `  `},               // 11
-		{in: &css.Token{Tok: css.DelimToken, Value: "."}, s: `.`},                      // 11
-		{in: &css.Token{Tok: css.IncludeMatchToken}, s: `~=`},                          // 11
-		{in: &css.Token{Tok: css.DashMatchToken}, s: `|=`},                             // 11
-		{in: &css.Token{Tok: css.PrefixMatchToken}, s: `^=`},                           // 11
-		{in: &css.Token{Tok: css.SuffixMatchToken}, s: `$=`},                           // 11
-		{in: &css.Token{Tok: css.SubstringMatchToken}, s: `*=`},                        // 11
-		{in: &css.Token{Tok: css.ColumnToken}, s: `||`},                                // 11
-		{in: &css.Token{Tok: css.CDOToken}, s: `<!--`},                                 // 11
-		{in: &css.Token{Tok: css.CDCToken}, s: `-->`},                                  // 11
-		{in: &css.Token{Tok: css.ColonToken}, s: `:`},                                  // 11
-		{in: &css.Token{Tok: css.SemicolonToken}, s: `;`},                              // 11
-		{in: &css.Token{Tok: css.CommaToken}, s: `,`},                                  // 11
-		{in: &css.Token{Tok: css.LBrackToken}, s: `[`},                                 // 11
-		{in: &css.Token{Tok: css.RBrackToken}, s: `]`},                                 // 11
-		{in: &css.Token{Tok: css.LParenToken}, s: `(`},                                 // 11
-		{in: &css.Token{Tok: css.RParenToken}, s: `)`},                                 // 11
-		{in: &css.Token{Tok: css.LBraceToken}, s: `{`},                                 // 11
-		{in: &css.Token{Tok: css.RBraceToken}, s: `}`},                                 // 11
+		{in: &css.Token{Tok: css.IdentToken, Value: "foo"}, s: `foo`},                  // 12
+		{in: &css.Token{Tok: css.FunctionToken, Value: "foo"}, s: `foo(`},              // 12
+		{in: &css.Token{Tok: css.AtKeywordToken, Value: "☃"}, s: `@☃`},                 // 12
+		{in: &css.Token{Tok: css.HashToken, Value: "foo"}, s: `#foo`},                  // 12
+		{in: &css.Token{Tok: css.StringToken, Value: "foo", Ending: '"'}, s: `"foo"`},  // 12
+		{in: &css.Token{Tok: css.StringToken, Value: "foo", Ending: '\''}, s: `'foo'`}, // 12
+		{in: &css.Token{Tok: css.BadStringToken}, s: `''`},                             // 12
+		{in: &css.Token{Tok: css.URLToken, Value: "foo"}, s: `url(foo)`},               // 12
+		{in: &css.Token{Tok: css.BadURLToken, Value: "foo"}, s: `url()`},               // 12
+		{in: &css.Token{Tok: css.DelimToken, Value: "."}, s: `.`},                      // 12
+		{in: &css.Token{Tok: css.NumberToken, Value: "-20.3E2"}, s: `-20.3E2`},         // 12
+		{in: &css.Token{Tok: css.PercentageToken, Value: "100%"}, s: `100%`},           // 12
+		{in: &css.Token{Tok: css.DimensionToken, Value: "10cm"}, s: `10cm`},            // 12
+		{in: &css.Token{Tok: css.WhitespaceToken, Value: "  "}, s: `  `},               // 12
+		{in: &css.Token{Tok: css.DelimToken, Value: "."}, s: `.`},                      // 12
+		{in: &css.Token{Tok: css.IncludeMatchToken}, s: `~=`},                          // 12
+		{in: &css.Token{Tok: css.DashMatchToken}, s: `|=`},                             // 12
+		{in: &css.Token{Tok: css.PrefixMatchToken}, s: `^=`},                           // 12
+		{in: &css.Token{Tok: css.SuffixMatchToken}, s: `$=`},                           // 12
+		{in: &css.Token{Tok: css.SubstringMatchToken}, s: `*=`},                        // 12
+		{in: &css.Token{Tok: css.ColumnToken}, s: `||`},                                // 12
+		{in: &css.Token{Tok: css.CDOToken}, s: `<!--`},                                 // 12
+		{in: &css.Token{Tok: css.CDCToken}, s: `-->`},                                  // 12
+		{in: &css.Token{Tok: css.ColonToken}, s: `:`},                                  // 12
+		{in: &css.Token{Tok: css.SemicolonToken}, s: `;`},                              // 12
+		{in: &css.Token{Tok: css.CommaToken}, s: `,`},                                  // 12
+		{in: &css.Token{Tok: css.LBrackToken}, s: `[`},                                 // 12
+		{in: &css.Token{Tok: css.RBrackToken}, s: `]`},                                 // 12
+		{in: &css.Token{Tok: css.LParenToken}, s: `(`},                                 // 12
+		{in: &css.Token{Tok: css.RParenToken}, s: `)`},                                 // 12
+		{in: &css.Token{Tok: css.LBraceToken}, s: `{`},                                 // 12
+		{in: &css.Token{Tok: css.RBraceToken}, s: `}`},                                 // 12
 
-		{in: &css.Token{Tok: css.UnicodeRangeToken, Start: 10, End: 10}, s: `U+00000a`},          // 11
-		{in: &css.Token{Tok: css.UnicodeRangeToken, Start: 10, End: 20}, s: `U+00000a-U+000014`}, // 11
+		{in: &css.Token{Tok: css.UnicodeRangeToken, Start: 10, End: 10}, s: `U+00000a`},          // 12
+		{in: &css.Token{Tok: css.UnicodeRangeToken, Start: 10, End: 20}, s: `U+00000a-U+000014`}, // 12
 
-		{in: &css.Token{Tok: css.EOFToken}, s: `EOF`}, // 11
+		{in: &css.Token{Tok: css.EOFToken}, s: `EOF`}, // 12
 	}
 
 	for i, tt := range tests {


### PR DESCRIPTION
### What I need

I would like to use another version of `SimpleBlock`, which has not `ComponentValues` but `Declarations`,

### Why
Reading css files and using `parser.ParseStyleSheet` , you can get a single AST with `ComponentValues` without `Declarations`.
Walking the tree and  converting with `parser.parseDeclarations(ComponentValueScanner)`, `Declarations` are obtained.
But `Declarations` cannot be set into the AST because `Values` in `SimpleBlock` cannot accept `Declarations`.
Although, I could achieve it by preparing another customized tree struct,
it is easier to handle intermediate processes if you can edit `Declarations` as partial branches in a single tree and print wit as package-level method.

#### Details
- Add interface `Block`
  - `Block` is either `SimpleBlock` or  `DeclarationBlock`
- Replace `SimpleBlock` with `Block` in `AtRule` and `QualifiedRule`
- new type `DeclarationBlock`
  - it has `Declarations` prop instead of `ComponentValues`
- add case to `Printer.Print`
- add some tests